### PR TITLE
Add Java files as build file pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
 			"./bazel-ls-eclipse/com.salesforce.b2eclipse.jdt.ls/target/com.salesforce.b2eclipse.jdt.ls-0.1.0-SNAPSHOT.jar"
 		],
 		"javaBuildFilePatterns": [
-			"^WORKSPACE(\\.bazel)?$", "^BUILD(\\.bazel)?$", ".*\\.bazelproject$"
+			"^WORKSPACE(\\.bazel)?$",
+			"^BUILD(\\.bazel)?$",
+			".*\\.bazelproject$",
+			".*\\.java$"
 		],
 		"commands": [
 			{


### PR DESCRIPTION
Add Java files as build file pattern. This allows us to update the Bazel project while the Java file is open.